### PR TITLE
Set installation type attribute on messenger boot

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -455,6 +455,12 @@ ___TEMPLATE_PARAMETERS___
                     "displayName": "Attribute Value",
                     "name": "attr_value",
                     "type": "TEXT"
+                  },
+                  {
+                    "defaultValue": "gtm",
+                    "displayName": "Installation type",
+                    "name": "installation_type",
+                    "type": "TEXT"
                   }
                 ],
                 "help": "Current user\u0027s company (Only applicable to users). Use variables as Attribute Name to specify custom company attributes.\nSee https://developers.intercom.com/installing-intercom/docs/javascript-api-attributes-objects#section-company-object for more details."
@@ -743,6 +749,7 @@ function setOrUpdateIntercomSettings(data) {
       settings[k] = custom_attrs[k];
     } 
   }
+  settings.installation_type = 'gtm';
   setInWindow('intercomSettings', settings, true);
   return settings;
 }
@@ -1413,6 +1420,35 @@ scenarios:
 
     // Verify that the tag finished successfully.
     assertApi('gtmOnSuccess').wasCalled();
+- name: installation_type_is_set
+  code: |-
+    const copyFromWindow = require('copyFromWindow');
+    const mockData = {
+      method: 'boot',
+      app_id: TEST_APP_ID
+    };
+
+    var q = copyFromWindow('Intercom.q') || [];
+    var q_len = q.length;
+
+    // Call runCode to run the template's code.
+    runCode(mockData);
+
+    // Verify window.Intercom.q has one item ['boot',[args]]
+    q = copyFromWindow('Intercom.q');
+    assertThat(q).hasLength(q_len+1);
+    var q_item = q[q_len];
+    assertThat(q_item).isArray();
+    assertThat(q_item[0]).isEqualTo('boot');
+
+    // Verify window.intercomSettings were updated correctly
+    var settings = copyFromWindow('intercomSettings');
+    assertThat(settings).isObject();
+    assertThat(settings.installation_type).isEqualTo('gtm');
+
+    // Verify that the tag finished successfully.
+    assertApi('gtmOnSuccess').wasCalled();
+
 - name: showNewMessage_works_with_prepopulated_message
   code: |-
     const copyFromWindow = require('copyFromWindow');


### PR DESCRIPTION
Towards https://github.com/intercom/intercom/issues/322688

I checked template tests by importing it as a new google tag, all passed succesfully.


### Tag template tests
<img width="475" alt="Screenshot 2024-02-19 at 15 32 57" src="https://github.com/intercom/official-gtm-tag/assets/4772270/ebf6268f-95e1-4a8d-b767-82845957682d">

### Installation with updated template version
<img width="1187" alt="Screenshot 2024-02-19 at 16 02 10" src="https://github.com/intercom/official-gtm-tag/assets/4772270/faa5378f-411d-4cf9-a8ba-76755ce09af6">


