### PR TITLE
Add last_request_at attribute

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,9 +2,11 @@ homepage: "https://www.intercom.com/"
 documentation: "https://developers.intercom.com/installing-intercom/docs/intercom-javascript"
 versions:
   # Latest version
+  - sha: be1d0e7067d9f1dbd8b947cefac02174b555c894
+    changeNotes: Add last_request_at attribute.
+  # Older versions
   - sha: 92520ff3f6aad0559a8a3a64ea288df2ce157f15
     changeNotes: Add showSpace and accompanying test to method options.
-  # Older versions
   - sha: f2fefe0e0da8d34c408a22d97823740989e83ecc
     changeNotes: Add installation_type attribute in the IntercomSettings
   - sha: 24064cfe22a14c89c4ca7c1de120d2aa69404761

--- a/template.tpl
+++ b/template.tpl
@@ -480,6 +480,15 @@ ___TEMPLATE_PARAMETERS___
                   }
                 ],
                 "help": "Current user\u0027s company (Only applicable to users). Use variables as Attribute Name to specify custom company attributes.\nSee https://developers.intercom.com/installing-intercom/docs/javascript-api-attributes-objects#section-company-object for more details."
+              },
+              {
+                "type": "TEXT",
+                "name": "last_request_at",
+                "displayName": "Last Request At",
+                "simpleValueType": true,
+                "valueHint": "Choose a variable",
+                "help": "(Optional) To perform a ping update without modifying the user data, populate this field with the current timestamp.",
+                "valueUnit": "Unix timestamp (in seconds)"
               }
             ],
             "enablingConditions": [
@@ -751,7 +760,7 @@ const dataLayerPush = createQueue('dataLayer');
 const makeTableMap = require('makeTableMap');
 log('data =', data);
 
-const DATA_ATTRS = ['email', 'user_id', 'created_at', 'name', 'phone', 'unsubscribed_from_emails', 'language_override', 'avatar_image_url', 'user_hash', 'company', 'companies'];
+const DATA_ATTRS = ['email', 'user_id', 'created_at', 'name', 'phone', 'unsubscribed_from_emails', 'language_override', 'avatar_image_url', 'user_hash', 'company', 'companies', 'last_request_at'];
 
 const COMPANY_INT_FIELDS = ['created_at', 'monthly_spend', 'size'];
 


### PR DESCRIPTION
Currently, we do not support GTM ping updates when user data has not changed.

However, in our public SPA setup documentation, we do allow this behavior using a JavaScript snippet with the `last_request_at` attribute:
[Intercom SPA Integration Guide](https://www.intercom.com/help/en/articles/170-integrate-intercom-in-a-single-page-app#tell-intercom-when-your-data-or-url-changes)

We aim to enable this same functionality via Google Tag Manager (GTM) in this PR.